### PR TITLE
Fix era/eon transition causing sync errors

### DIFF
--- a/bin/node-template-spartan/runtime/src/lib.rs
+++ b/bin/node-template-spartan/runtime/src/lib.rs
@@ -456,7 +456,6 @@ impl_runtime_apis! {
         }
 
         fn solution_range() -> u64 {
-            // TODO: Maybe this is not a correct value to have a default value
             PoC::solution_range().unwrap_or_else(InitialSolutionRange::get)
         }
 

--- a/client/consensus/poc/src/tests.rs
+++ b/client/consensus/poc/src/tests.rs
@@ -161,7 +161,7 @@ impl DummyProposer {
             block.header.digest_mut().push(digest)
         }
         {
-            let digest_data = ConsensusLog::NextSolutionRangeData(NextSolutionRangeDescriptor {
+            let digest_data = ConsensusLog::SolutionRangeData(SolutionRangeDescriptor {
                 solution_range: u64::MAX,
             })
             .encode();
@@ -169,7 +169,7 @@ impl DummyProposer {
             block.header.digest_mut().push(digest)
         }
         {
-            let digest_data = ConsensusLog::NextSaltData(NextSaltDescriptor { salt: 0 }).encode();
+            let digest_data = ConsensusLog::SaltData(SaltDescriptor { salt: 0 }).encode();
             let digest = DigestItem::Consensus(POC_ENGINE_ID, digest_data);
             block.header.digest_mut().push(digest)
         }

--- a/frame/spartan/src/tests.rs
+++ b/frame/spartan/src/tests.rs
@@ -248,7 +248,7 @@ fn can_enact_next_config() {
             });
         let consensus_digest = DigestItem::Consensus(POC_ENGINE_ID, consensus_log.encode());
 
-        assert_eq!(header.digest.logs[2], consensus_digest.clone())
+        assert_eq!(header.digest.logs[4], consensus_digest.clone())
     });
 }
 

--- a/primitives/consensus/poc/src/digests.rs
+++ b/primitives/consensus/poc/src/digests.rs
@@ -99,15 +99,30 @@ impl From<NextConfigDescriptor> for PoCEpochConfiguration {
     }
 }
 
+/// Information about the solution range for the block.
+#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+pub struct SolutionRangeDescriptor {
+    /// Solution range used for challenges.
+    pub solution_range: u64,
+}
+
+/// Salt for the block.
+#[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
+pub struct SaltDescriptor {
+    /// Salt used with challenges.
+    pub salt: u64,
+}
+
 /// Information about the solution range, if changed. This is broadcast in the first
-/// block of the era.
+/// block of the era, but only applies to the block after that.
 #[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
 pub struct NextSolutionRangeDescriptor {
     /// Solution range used for challenges.
     pub solution_range: u64,
 }
 
-/// Salt, if changed. This is broadcast in the each block of the eon.
+/// Salt, if changed. This is broadcast in the each block of the eon, but only applies to the block
+/// after that.
 #[derive(Decode, Encode, PartialEq, Eq, Clone, RuntimeDebug)]
 pub struct NextSaltDescriptor {
     /// Salt used with challenges.

--- a/primitives/consensus/poc/src/lib.rs
+++ b/primitives/consensus/poc/src/lib.rs
@@ -33,6 +33,7 @@ use sp_std::vec::Vec;
 
 use crate::digests::{
     NextConfigDescriptor, NextEpochDescriptor, NextSaltDescriptor, NextSolutionRangeDescriptor,
+    SaltDescriptor, SolutionRangeDescriptor,
 };
 
 /// Key type for PoC module.
@@ -78,11 +79,17 @@ pub enum ConsensusLog {
     /// enact different epoch configurations.
     #[codec(index = 2)]
     NextConfigData(NextConfigDescriptor),
-    /// The era has changed, and the solution range has changed.
+    /// Solution range for this block.
     #[codec(index = 3)]
-    NextSolutionRangeData(NextSolutionRangeDescriptor),
-    /// The eon has changed, and the salt has changed.
+    SolutionRangeData(SolutionRangeDescriptor),
+    /// Salt for this block.
     #[codec(index = 4)]
+    SaltData(SaltDescriptor),
+    /// The era has changed and the solution range has changed because of that.
+    #[codec(index = 5)]
+    NextSolutionRangeData(NextSolutionRangeDescriptor),
+    /// The eon has changed and the salt has changed because of that.
+    #[codec(index = 6)]
     NextSaltData(NextSaltDescriptor),
 }
 


### PR DESCRIPTION
Essentially we were using out of date solution range and salt on era/eon transition for notifications to farmers, but stored the correct value in the block itself, which caused verification errors when some other node tried to sync.

Fixes #8, fixes #9