### PR TITLE
Added start-farmer and start-node bash scripts

### DIFF
--- a/bin/node-template-spartan/run-node-farmer-pair.sh
+++ b/bin/node-template-spartan/run-node-farmer-pair.sh
@@ -2,16 +2,18 @@
 set -e
 
 if [ $# -eq 0 ]; then
-    echo -e "Usage:\n  $0 <instance_id>\nWhere <instance_id> should be unique for each call, for example:\n  $0 first"
+    echo -e "Usage:\n  $0 <instance_id> <bootstrap_ip>\nWhere <instance_id> should be unique for each call, for example:\n  $0 first \nWhere <bootstrap_ip> provide remote bootstrap node ip for remote connection, alternatively assumed to be local. for example: \n  $0 farm 0.0.0.0"
     exit 1
 fi
 
+BOOTSTRAP_CLIENT_IP=${2:-$(docker inspect -f "{{.NetworkSettings.Networks.spartan.IPAddress}}" node-template-spartan)}
+
 cd $(dirname ${BASH_SOURCE[0]})
 
-export BOOTSTRAP_CLIENT_IP="165.232.157.230"
+export BOOTSTRAP_CLIENT_IP
 export INSTANCE_ID="$1"
 export COMPOSE_PROJECT_NAME="spartan-$INSTANCE_ID"
-
+echo "${2:-$(docker inspect -f "{{.NetworkSettings.Networks.spartan.IPAddress}}" node-template-spartan)}"
 stop() {
   docker-compose down -t 3 || /bin/true
   docker volume rm spartan-farmer-$INSTANCE_ID

--- a/bin/node-template-spartan/run-node-farmer-pair.sh
+++ b/bin/node-template-spartan/run-node-farmer-pair.sh
@@ -8,7 +8,7 @@ fi
 
 cd $(dirname ${BASH_SOURCE[0]})
 
-export BOOTSTRAP_CLIENT_IP=$(docker inspect -f "{{.NetworkSettings.Networks.spartan.IPAddress}}" node-template-spartan)
+export BOOTSTRAP_CLIENT_IP="165.232.157.230"
 export INSTANCE_ID="$1"
 export COMPOSE_PROJECT_NAME="spartan-$INSTANCE_ID"
 

--- a/bin/node-template-spartan/run-node-farmer-pair.sh
+++ b/bin/node-template-spartan/run-node-farmer-pair.sh
@@ -13,7 +13,6 @@ cd $(dirname ${BASH_SOURCE[0]})
 export BOOTSTRAP_CLIENT_IP
 export INSTANCE_ID="$1"
 export COMPOSE_PROJECT_NAME="spartan-$INSTANCE_ID"
-echo "${2:-$(docker inspect -f "{{.NetworkSettings.Networks.spartan.IPAddress}}" node-template-spartan)}"
 stop() {
   docker-compose down -t 3 || /bin/true
   docker volume rm spartan-farmer-$INSTANCE_ID

--- a/bin/node-template-spartan/start-farmer.sh
+++ b/bin/node-template-spartan/start-farmer.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+setup() {
+    echo "Setting up docker Network, Volume, and Pulling Repo..."
+    docker network create spartan
+    docker volume create spartan-farmer
+    docker pull subspacelabs/spartan-farmer
+    echo "Setup Complete."
+}
+run-farm() {
+    echo "Starting Farm..."
+    docker run --rm --init -it \
+    --net spartan \
+    --name spartan-farmer \
+    --mount source=spartan-farmer,target=/var/spartan \
+    subspacelabs/spartan-farmer \
+        farm \
+        --ws-server ws://node-template-spartan-full:9944
+}
+plot-1gb() {
+    echo "Plotting 1gb..."
+    docker run --rm -it \
+        --name spartan-farmer \
+        --mount source=spartan-farmer,target=/var/spartan \
+        subspacelabs/spartan-farmer plot 256000 spartan
+}
+wipe() {
+    echo "Wiping prior installation..."
+    docker container kill spartan-farmer
+    docker volume rm spartan-farmer
+}
+erase() {
+    echo "Erasing plot..."
+    docker container kill spartan-farmer
+    docker run --rm -it \
+    --name spartan-farmer \
+    --mount source=spartan-farmer,target=/var/spartan \
+    subspacelabs/spartan-farmer erase-plot
+}
+##
+# Color  Variables
+##
+green='\e[32m'
+blue='\e[34m'
+clear='\e[0m'
+
+##
+# Color Functions
+##
+
+ColorGreen(){
+	echo -ne $green$1$clear
+}
+ColorBlue(){
+	echo -ne $blue$1$clear
+}
+
+menu(){
+echo -ne "
+----------------------------------
+           F A R M E R
+ -=[Subspace - Spartan Testnet]=- 
+----------------------------------
+$(ColorGreen '1)') Setup/Update Farmer
+$(ColorGreen '2)') Plot 1GB of Data
+$(ColorGreen '3)') Run Farmer
+$(ColorGreen '4)') Wipe Farmer
+$(ColorGreen '5)') Erase Plot
+$(ColorGreen '0)') Exit
+$(ColorBlue 'Choose an option:') "
+        read a
+        case $a in
+	        1) setup ; menu ;;
+	        2) plot-1gb ; menu ;;
+            3) run-farm ; menu ;;
+	        4) wipe ; menu ;;
+            5) erase ; menu ;;
+		0) exit 0 ;;
+		*) echo -e $red"Wrong option."$clear; WrongCommand;;
+        esac
+}
+menu

--- a/bin/node-template-spartan/start-farmer.sh
+++ b/bin/node-template-spartan/start-farmer.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 setup() {
     echo "Setting up docker Network, Volume, and Pulling Repo..."
     docker network create spartan
@@ -6,6 +9,7 @@ setup() {
     docker pull subspacelabs/spartan-farmer
     echo "Setup Complete."
 }
+
 run-farm() {
     echo "Starting Farm..."
     docker run --rm --init -it \
@@ -16,12 +20,13 @@ run-farm() {
         farm \
         --ws-server ws://node-template-spartan-full:9944
 }
+
 plot-1gb() {
     echo "Plotting 1gb..."
     docker run --rm -it \
-        --name spartan-farmer \
-        --mount source=spartan-farmer,target=/var/spartan \
-        subspacelabs/spartan-farmer plot 256000 spartan
+    --name spartan-farmer \
+    --mount source=spartan-farmer,target=/var/spartan \
+    subspacelabs/spartan-farmer plot 256000 spartan
 }
 wipe() {
     echo "Wiping prior installation..."
@@ -48,34 +53,34 @@ clear='\e[0m'
 ##
 
 ColorGreen(){
-	echo -ne $green$1$clear
+    echo -ne $green$1$clear
 }
 ColorBlue(){
-	echo -ne $blue$1$clear
+    echo -ne $blue$1$clear
 }
 
 menu(){
-echo -ne "
-----------------------------------
-           F A R M E R
- -=[Subspace - Spartan Testnet]=- 
-----------------------------------
-$(ColorGreen '1)') Setup/Update Farmer
-$(ColorGreen '2)') Plot 1GB of Data
-$(ColorGreen '3)') Run Farmer
-$(ColorGreen '4)') Wipe Farmer
-$(ColorGreen '5)') Erase Plot
-$(ColorGreen '0)') Exit
-$(ColorBlue 'Choose an option:') "
-        read a
-        case $a in
-	        1) setup ; menu ;;
-	        2) plot-1gb ; menu ;;
-            3) run-farm ; menu ;;
-	        4) wipe ; menu ;;
-            5) erase ; menu ;;
-		0) exit 0 ;;
-		*) echo -e $red"Wrong option."$clear; WrongCommand;;
-        esac
+    echo -ne "
+    ----------------------------------
+    F A R M E R
+    -=[Subspace - Spartan Testnet]=- 
+    ----------------------------------
+    $(ColorGreen '1)') Setup/Update Farmer
+    $(ColorGreen '2)') Plot 1GB of Data
+    $(ColorGreen '3)') Run Farmer
+    $(ColorGreen '4)') Wipe Farmer
+    $(ColorGreen '5)') Erase Plot
+    $(ColorGreen '0)') Exit
+    $(ColorBlue 'Choose an option:') "
+    read a
+    case $a in
+        1) setup ; menu ;;
+        2) plot-1gb ; menu ;;
+        3) run-farm ; menu ;;
+        4) wipe ; menu ;;
+        5) erase ; menu ;;
+        0) exit 0 ;;
+        *) echo -e $red"Wrong option."$clear; WrongCommand;;
+    esac
 }
 menu

--- a/bin/node-template-spartan/start-farmer.sh
+++ b/bin/node-template-spartan/start-farmer.sh
@@ -3,11 +3,13 @@
 set -e
 
 setup() {
+    set +e # disable exit on error, due to the fact the network may be created prior
     echo "Setting up docker Network, Volume, and Pulling Repo..."
     docker network create spartan
     docker volume create spartan-farmer
     docker pull subspacelabs/spartan-farmer
-    echo "Setup Complete."
+    echo "Setup/Update Complete."
+    set -e
 }
 
 run-farm() {
@@ -71,7 +73,9 @@ menu(){
     $(ColorGreen '4)') Wipe Farmer
     $(ColorGreen '5)') Erase Plot
     $(ColorGreen '0)') Exit
-    $(ColorBlue 'Choose an option:') "
+    $(ColorBlue 'Choose an option:') $clear"
+    
+
     read a
     case $a in
         1) setup ; menu ;;
@@ -80,7 +84,7 @@ menu(){
         4) wipe ; menu ;;
         5) erase ; menu ;;
         0) exit 0 ;;
-        *) echo -e $red"Wrong option."$clear; WrongCommand;;
+        *) echo -e $red"Not a Valid Option, Try Again..."; menu;;
     esac
 }
 menu

--- a/bin/node-template-spartan/start-farmer.sh
+++ b/bin/node-template-spartan/start-farmer.sh
@@ -3,13 +3,11 @@
 set -e
 
 setup() {
-    set +e # disable exit on error, due to the fact the network may be created prior
     echo "Setting up docker Network, Volume, and Pulling Repo..."
-    docker network create spartan
-    docker volume create spartan-farmer
+    docker network create spartan || /bin/true
+    docker volume create spartan-farmer || /bin/true
     docker pull subspacelabs/spartan-farmer
     echo "Setup/Update Complete."
-    set -e
 }
 
 run-farm() {
@@ -84,7 +82,7 @@ menu(){
         4) wipe ; menu ;;
         5) erase ; menu ;;
         0) exit 0 ;;
-        *) echo -e $red"Not a Valid Option, Try Again..."; menu;;
+        *) echo -e "Not a Valid Option, Try Again..."; menu;;
     esac
 }
 menu

--- a/bin/node-template-spartan/start-farmer.sh
+++ b/bin/node-template-spartan/start-farmer.sh
@@ -62,7 +62,7 @@ ColorBlue(){
 menu(){
     echo -ne "
     ----------------------------------
-    F A R M E R
+                F A R M E R
     -=[Subspace - Spartan Testnet]=- 
     ----------------------------------
     $(ColorGreen '1)') Setup/Update Farmer

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 setup() {
     echo "Setting up docker Network, Volume, and Pulling Repo..."
     docker network create spartan

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -3,11 +3,13 @@
 set -e
 
 setup() {
+    set +e # disable exit on error, due to the fact the network may be created prior
     echo "Setting up docker Network, Volume, and Pulling Repo..."
     docker network create spartan
     docker volume create spartan-node-template
     docker pull subspacelabs/node-template-spartan
-    echo "Setup Complete."
+    echo "Setup/Update Complete."
+    set -e
 }
 run-full() {
     echo "Running Full Node..."
@@ -60,7 +62,8 @@ menu(){
     $(ColorGreen '3)') Kill Node
     $(ColorGreen '4)') Wipe Node
     $(ColorGreen '0)') Exit
-    $(ColorBlue 'Choose an option:') "
+    $(ColorBlue 'Choose an option:') $clear"
+    
     read a
     case $a in
         1) setup ; menu ;;
@@ -68,7 +71,7 @@ menu(){
         3) killnode ; menu ;;
         4) wipe ; menu ;;
         0) exit 0 ;;
-        *) echo -e $red"Wrong option."$clear; WrongCommand;;
+        *) echo -e $red"Not a Valid Option, Try Again..."; menu;;
     esac
 }
 menu

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -3,10 +3,9 @@
 set -e
 
 setup() {
-    set +e # disable exit on error, due to the fact the network may be created prior
     echo "Setting up docker Network, Volume, and Pulling Repo..."
-    docker network create spartan
-    docker volume create spartan-node-template
+    docker network create spartan || /bin/true
+    docker volume create spartan-node-template || /bin/true
     docker pull subspacelabs/node-template-spartan
     echo "Setup/Update Complete."
     set -e
@@ -71,7 +70,7 @@ menu(){
         3) killnode ; menu ;;
         4) wipe ; menu ;;
         0) exit 0 ;;
-        *) echo -e $red"Not a Valid Option, Try Again..."; menu;;
+        *) echo -e "Not a Valid Option, Try Again..."; menu;;
     esac
 }
 menu

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -8,7 +8,6 @@ setup() {
     docker volume create spartan-node-template || /bin/true
     docker pull subspacelabs/node-template-spartan
     echo "Setup/Update Complete."
-    set -e
 }
 run-full() {
     echo "Running Full Node..."

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -16,11 +16,11 @@ run-full() {
     --name node-template-spartan-full \
     --mount source=node-template-spartan,target=/var/spartan \
     subspacelabs/node-template-spartan \
-    --dev \
-    --base-path /var/spartan \
-    --ws-external \
-    --bootnodes /ip4/165.232.157.230/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
-    --telemetry-url 'wss://telemetry.polkadot.io/submit/ 9'
+        --dev \
+        --base-path /var/spartan \
+        --ws-external \
+        --bootnodes /ip4/165.232.157.230/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
+        --telemetry-url 'wss://telemetry.polkadot.io/submit/ 9'
 }
 killnode() {
     echo "Killing Node..."
@@ -43,32 +43,32 @@ clear='\e[0m'
 ##
 
 ColorGreen(){
-	echo -ne $green$1$clear
+echo -ne $green$1$clear
 }
 ColorBlue(){
-	echo -ne $blue$1$clear
+echo -ne $blue$1$clear
 }
 
 menu(){
-echo -ne "
-----------------------------------
-             N O D E              
- -=[Subspace - Spartan Testnet]=- 
-----------------------------------
-$(ColorGreen '1)') Setup/Update Node
-$(ColorGreen '2)') Run Full Node
-$(ColorGreen '3)') Kill Node
-$(ColorGreen '4)') Wipe Node
-$(ColorGreen '0)') Exit
-$(ColorBlue 'Choose an option:') "
-        read a
-        case $a in
-	        1) setup ; menu ;;
-	        2) run-full ; menu ;;
-	        3) killnode ; menu ;;
-            4) wipe ; menu ;;
-		0) exit 0 ;;
-		*) echo -e $red"Wrong option."$clear; WrongCommand;;
-        esac
+    echo -ne "
+    ----------------------------------
+                N O D E              
+    -=[Subspace - Spartan Testnet]=- 
+    ----------------------------------
+    $(ColorGreen '1)') Setup/Update Node
+    $(ColorGreen '2)') Run Full Node
+    $(ColorGreen '3)') Kill Node
+    $(ColorGreen '4)') Wipe Node
+    $(ColorGreen '0)') Exit
+    $(ColorBlue 'Choose an option:') "
+    read a
+    case $a in
+        1) setup ; menu ;;
+        2) run-full ; menu ;;
+        3) killnode ; menu ;;
+        4) wipe ; menu ;;
+        0) exit 0 ;;
+        *) echo -e $red"Wrong option."$clear; WrongCommand;;
+    esac
 }
 menu

--- a/bin/node-template-spartan/start-node.sh
+++ b/bin/node-template-spartan/start-node.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+setup() {
+    echo "Setting up docker Network, Volume, and Pulling Repo..."
+    docker network create spartan
+    docker volume create spartan-node-template
+    docker pull subspacelabs/node-template-spartan
+    echo "Setup Complete."
+}
+run-full() {
+    echo "Running Full Node..."
+    docker run --rm --init -it \
+    --net spartan \
+    --name node-template-spartan-full \
+    --mount source=node-template-spartan,target=/var/spartan \
+    subspacelabs/node-template-spartan \
+    --dev \
+    --base-path /var/spartan \
+    --ws-external \
+    --bootnodes /ip4/165.232.157.230/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp \
+    --telemetry-url 'wss://telemetry.polkadot.io/submit/ 9'
+}
+killnode() {
+    echo "Killing Node..."
+    docker kill node-template-spartan-full
+}
+wipe() {
+    echo "Wiping prior installation..."
+    docker container kill node-template-spartan-full
+    docker volume rm spartan-node-template
+}
+##
+# Color  Variables
+##
+green='\e[32m'
+blue='\e[34m'
+clear='\e[0m'
+
+##
+# Color Functions
+##
+
+ColorGreen(){
+	echo -ne $green$1$clear
+}
+ColorBlue(){
+	echo -ne $blue$1$clear
+}
+
+menu(){
+echo -ne "
+----------------------------------
+             N O D E              
+ -=[Subspace - Spartan Testnet]=- 
+----------------------------------
+$(ColorGreen '1)') Setup/Update Node
+$(ColorGreen '2)') Run Full Node
+$(ColorGreen '3)') Kill Node
+$(ColorGreen '4)') Wipe Node
+$(ColorGreen '0)') Exit
+$(ColorBlue 'Choose an option:') "
+        read a
+        case $a in
+	        1) setup ; menu ;;
+	        2) run-full ; menu ;;
+	        3) killnode ; menu ;;
+            4) wipe ; menu ;;
+		0) exit 0 ;;
+		*) echo -e $red"Wrong option."$clear; WrongCommand;;
+        esac
+}
+menu


### PR DESCRIPTION
Added scripts to help users run their farmers and nodes

`./start-farmer.sh` will give the following options:

- Setup/Update Farmer
- Plot 1GB of Data
- Run Farmer
- Wipe Farmer
- Erase Plot
- Exit

`./start-node.sh` will give the following options:

- Setup/Update Node
- Run Full Node
- Kill Node
- Wipe Node
- Exit

These help the user manage the farmers and nodes with less CLI use.


This pull request will also resolve the node-farmer-pair script not being able to run, see the linked issue. 