### PR TITLE
Draft: Block relay POC (proposal 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9282,6 +9282,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
+ "parity-scale-codec",
  "serde",
  "serde_json",
  "sp-blockchain",

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -201,6 +201,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			import_queue,
 			block_announce_validator_builder: None,
 			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			block_relay: None,
 		})?;
 
 	if config.offchain_worker.enabled {

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -362,6 +362,7 @@ pub fn new_full_base(
 			import_queue,
 			block_announce_validator_builder: None,
 			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			block_relay: None,
 		})?;
 
 	if config.offchain_worker.enabled {

--- a/client/network/sync/src/block_relay_protocol.rs
+++ b/client/network/sync/src/block_relay_protocol.rs
@@ -1,0 +1,55 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Block relay protocol related definitions.
+
+use crate::service::network::NetworkServiceHandle;
+use futures::channel::oneshot;
+use libp2p::PeerId;
+use sc_network_common::request_responses::{ProtocolConfig, RequestFailure};
+use sp_runtime::traits::{Block as BlockT};
+use std::sync::Arc;
+
+/// The serving side of the block relay protocol. It runs a single instance
+/// of the server task  that processes the incoming protocol messages.
+#[async_trait::async_trait]
+pub trait BlockServer<Block: BlockT>: Send {
+	/// Starts the protocol processing.
+	async fn run(&mut self);
+}
+
+/// The client side stub to download blocks from peers. This is a handle that can
+/// be used to initiate concurrent downloads.
+#[async_trait::async_trait]
+pub trait BlockDownloader: Send + Sync {
+	/// Performs the protocol specific sequence to fetch the block from the peer.
+	/// Input: request is serialized schema::v1::BlockRequest.
+	/// Output: if the protocol succeeds, serialized schema::v1::BlockResponse is returned.
+	async fn download_block(
+		&self,
+		who: PeerId,
+		request: Vec<u8>,
+		network: NetworkServiceHandle,
+	) -> Result<Result<Vec<u8>, RequestFailure>, oneshot::Canceled>;
+}
+
+/// Block relay specific params for network creation.
+pub struct BlockRelayParams<Block: BlockT> {
+	pub server: Box<dyn BlockServer<Block>>,
+	pub downloader: Arc<dyn BlockDownloader>,
+	pub request_response_config: ProtocolConfig,
+}
+

--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -17,6 +17,8 @@
 //! Helper for handling (i.e. answering) block requests from a remote peer via the
 //! `crate::request_responses::RequestResponsesBehaviour`.
 
+use crate::block_relay_protocol::{BlockServer, BlockDownloader, BlockRelayParams};
+use crate::service::network::NetworkServiceHandle;
 use crate::schema::v1::{block_request::FromBlock, BlockResponse, Direction};
 use codec::{Decode, Encode};
 use futures::{
@@ -30,7 +32,10 @@ use prost::Message;
 use sc_client_api::BlockBackend;
 use sc_network_common::{
 	config::ProtocolId,
-	request_responses::{IncomingRequest, OutgoingResponse, ProtocolConfig},
+	protocol::ProtocolName,
+	request_responses::{
+		IfDisconnected, IncomingRequest, OutgoingResponse, ProtocolConfig, RequestFailure
+	},
 	sync::message::BlockAttributes,
 };
 use sp_blockchain::HeaderBackend;
@@ -149,7 +154,7 @@ where
 		fork_id: Option<&str>,
 		client: Arc<Client>,
 		num_peer_hint: usize,
-	) -> (Self, ProtocolConfig) {
+	) -> BlockRelayParams<B> {
 		// Reserve enough request slots for one request per peer when we are at the maximum
 		// number of peers.
 		let (tx, request_receiver) = mpsc::channel(num_peer_hint);
@@ -169,11 +174,16 @@ where
 			NonZeroUsize::new(num_peer_hint.max(1) * 2).expect("cache capacity is not zero");
 		let seen_requests = LruCache::new(capacity);
 
-		(Self { client, request_receiver, seen_requests }, protocol_config)
+		BlockRelayParams {
+			server: Box::new(Self { client, request_receiver, seen_requests }),
+			downloader: Arc::new(FullBlockDownloader::new(protocol_config.name.clone())),
+			request_response_config: protocol_config,
+
+		}
 	}
 
 	/// Run [`BlockRequestHandler`].
-	pub async fn run(mut self) {
+	async fn process_requests(&mut self) {
 		while let Some(request) = self.request_receiver.next().await {
 			let IncomingRequest { peer, payload, pending_response } = request;
 
@@ -447,6 +457,17 @@ where
 	}
 }
 
+#[async_trait::async_trait]
+impl<B, Client> BlockServer<B> for BlockRequestHandler<B, Client>
+	where
+		B: BlockT,
+		Client: HeaderBackend<B> + BlockBackend<B> + Send + Sync + 'static,
+{
+	async fn run(&mut self) {
+		self.process_requests().await;
+	}
+}
+
 #[derive(Debug, thiserror::Error)]
 enum HandleRequestError {
 	#[error("Failed to decode request: {0}.")]
@@ -463,4 +484,37 @@ enum HandleRequestError {
 	Client(#[from] sp_blockchain::Error),
 	#[error("Failed to send response.")]
 	SendResponse,
+}
+
+pub struct FullBlockDownloader {
+	protocol_name: ProtocolName,
+}
+
+impl FullBlockDownloader {
+	fn new(protocol_name: ProtocolName) -> Self {
+		Self {
+			protocol_name
+		}
+	}
+}
+
+/// The full block download implementation.
+#[async_trait::async_trait]
+impl BlockDownloader for FullBlockDownloader {
+	async fn download_block(
+		&self,
+		who: PeerId,
+		request: Vec<u8>,
+		network: NetworkServiceHandle,
+	) -> Result<Result<Vec<u8>, RequestFailure>, oneshot::Canceled> {
+		let (tx, rx) = oneshot::channel();
+		network.start_request(
+			who,
+			self.protocol_name.clone(),
+			request,
+			tx,
+			IfDisconnected::ImmediateError,
+		);
+		rx.await
+	}
 }

--- a/client/network/sync/src/block_request_handler.rs
+++ b/client/network/sync/src/block_request_handler.rs
@@ -26,7 +26,7 @@ use futures::{
 	stream::StreamExt,
 };
 use libp2p::PeerId;
-use log::debug;
+use log::{debug, info};
 use lru::LruCache;
 use prost::Message;
 use sc_client_api::BlockBackend;
@@ -184,6 +184,10 @@ where
 
 	/// Run [`BlockRequestHandler`].
 	async fn process_requests(&mut self) {
+		info!(
+			target: LOG_TARGET,
+			"BlockRequestHandler::process_requests(): started"
+		);
 		while let Some(request) = self.request_receiver.next().await {
 			let IncomingRequest { peer, payload, pending_response } = request;
 

--- a/client/network/sync/src/schema.rs
+++ b/client/network/sync/src/schema.rs
@@ -18,6 +18,6 @@
 
 //! Include sources generated from protobuf definitions.
 
-pub(crate) mod v1 {
+pub mod v1 {
 	include!(concat!(env!("OUT_DIR"), "/api.v1.rs"));
 }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -47,6 +47,7 @@ use sc_network_common::{
 };
 use sc_network_light::light_client_requests::handler::LightClientRequestHandler;
 use sc_network_sync::{
+	block_relay_protocol::BlockRelayParams,
 	block_request_handler::BlockRequestHandler, service::network::NetworkServiceProvider,
 	state_request_handler::StateRequestHandler,
 	warp_request_handler::RequestHandler as WarpSyncRequestHandler, ChainSync,
@@ -761,6 +762,9 @@ pub struct BuildNetworkParams<'a, TBl: BlockT, TExPool, TImpQu, TCl> {
 		Option<Box<dyn FnOnce(Arc<TCl>) -> Box<dyn BlockAnnounceValidator<TBl> + Send> + Send>>,
 	/// Optional warp sync params.
 	pub warp_sync_params: Option<WarpSyncParams<TBl>>,
+	/// User specified block relay params. If not specified, the default
+	/// block request handler will be used.
+	pub block_relay: Option<BlockRelayParams<TBl>>,
 }
 /// Build the network service, the network status sinks and an RPC sender.
 pub fn build_network<TBl, TExPool, TImpQu, TCl>(
@@ -796,6 +800,7 @@ where
 		import_queue,
 		block_announce_validator_builder,
 		warp_sync_params,
+		block_relay,
 	} = params;
 
 	let mut request_response_protocol_configs = Vec::new();
@@ -820,18 +825,23 @@ where
 		Box::new(DefaultBlockAnnounceValidator)
 	};
 
-	let block_request_protocol_config = {
-		// Allow both outgoing and incoming requests.
-		let (handler, protocol_config) = BlockRequestHandler::new(
-			&protocol_id,
-			config.chain_spec.fork_id(),
-			client.clone(),
-			config.network.default_peers_set.in_peers as usize +
-				config.network.default_peers_set.out_peers as usize,
-		);
-		spawn_handle.spawn("block-request-handler", Some("networking"), handler.run());
-		protocol_config
+	let (mut block_server, block_downloader, block_request_protocol_config) = match block_relay {
+		Some(params) => (params.server, params.downloader, params.request_response_config),
+		None => {
+			// Custom protocol was not specified, use the default block handler.
+			let params = BlockRequestHandler::new(
+				&protocol_id,
+				config.chain_spec.fork_id(),
+				client.clone(),
+				config.network.default_peers_set.in_peers as usize +
+					config.network.default_peers_set.out_peers as usize,
+			);
+			(params.server, params.downloader, params.request_response_config)
+		}
 	};
+	spawn_handle.spawn("block-request-handler", Some("networking"), async move {
+		block_server.run().await;
+	});
 
 	let state_request_protocol_config = {
 		// Allow both outgoing and incoming requests.
@@ -893,7 +903,7 @@ where
 		config.prometheus_config.as_ref().map(|config| config.registry.clone()).as_ref(),
 		chain_sync_network_handle,
 		import_queue.service(),
-		block_request_protocol_config.name.clone(),
+		block_downloader,
 		state_request_protocol_config.name.clone(),
 		warp_sync_protocol_config.as_ref().map(|config| config.name.clone()),
 		config.network.force_synced,

--- a/client/transaction-pool/api/Cargo.toml
+++ b/client/transaction-pool/api/Cargo.toml
@@ -10,6 +10,7 @@ description = "Transaction pool client facing API."
 
 [dependencies]
 async-trait = "0.1.57"
+codec = { package = "parity-scale-codec", version = "3.2.2" }
 futures = "0.3.21"
 log = "0.4.17"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/client/transaction-pool/api/src/lib.rs
+++ b/client/transaction-pool/api/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod error;
 
 use async_trait::async_trait;
+use codec::Codec;
 use futures::{Future, Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sp_runtime::{
@@ -186,7 +187,7 @@ pub trait TransactionPool: Send + Sync {
 	/// Block type.
 	type Block: BlockT;
 	/// Transaction hash type.
-	type Hash: Hash + Eq + Member + Serialize + DeserializeOwned;
+	type Hash: Hash + Eq + Member + Serialize + DeserializeOwned + Codec;
 	/// In-pool transaction type.
 	type InPoolTransaction: InPoolTransaction<
 		Transaction = TransactionFor<Self>,


### PR DESCRIPTION
Main changes:
1.` ChainSync` currently calls into the block request handler directly. Instead, move the block request handler behind a trait. This allows new protocols to be plugged into ChainSync.
2. `BuildNetworkParams` is changed so that custom relay protocol implementations can be (optionally) passed in during network creation time. If custom protocol is not specified, it defaults to the existing block handler
3. `BlockServer` and `BlockDownloader` traits are introduced for the protocol implementation. The existing block handler has been changed to implement these traits

