### PR TITLE
Draft: modular block request handler(proposal 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9600,6 +9600,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
+ "parity-scale-codec",
  "serde",
  "serde_json",
  "sp-blockchain",

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -179,6 +179,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 			import_queue,
 			block_announce_validator_builder: None,
 			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			block_relay: None,
 		})?;
 
 	if config.offchain_worker.enabled {

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -363,6 +363,7 @@ pub fn new_full_base(
 			import_queue,
 			block_announce_validator_builder: None,
 			warp_sync_params: Some(WarpSyncParams::WithProvider(warp_sync)),
+			block_relay: None,
 		})?;
 
 	if config.offchain_worker.enabled {

--- a/client/network/sync/src/block_relay_protocol.rs
+++ b/client/network/sync/src/block_relay_protocol.rs
@@ -1,0 +1,56 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Block relay protocol related definitions.
+
+use crate::service::network::NetworkServiceHandle;
+use futures::channel::oneshot;
+use libp2p::PeerId;
+use sc_network::request_responses::{ProtocolConfig, RequestFailure};
+use sp_runtime::traits::{Block as BlockT};
+use std::sync::Arc;
+
+/// The serving side of the block relay protocol. It runs a single instance
+/// of the server task  that processes the incoming protocol messages.
+#[async_trait::async_trait]
+pub trait BlockServer<Block: BlockT>: Send {
+	/// Starts the protocol processing.
+	async fn run(&mut self);
+}
+
+/// The client side stub to download blocks from peers. This is a handle that can
+/// be used to initiate concurrent downloads.
+#[async_trait::async_trait]
+pub trait BlockDownloader: Send + Sync {
+	/// Performs the protocol specific sequence to fetch the block from the peer.
+	/// Input: request is serialized schema::v1::BlockRequest.
+	/// Output: if the protocol succeeds, serialized schema::v1::BlockResponse is returned.
+	async fn download_block(
+		&self,
+		who: PeerId,
+		request: Vec<u8>,
+		network: NetworkServiceHandle,
+	) -> Result<Result<Vec<u8>, RequestFailure>, oneshot::Canceled>;
+}
+
+/// Block relay specific params for network creation.
+pub struct BlockRelayParams<Block: BlockT> {
+	pub server: Box<dyn BlockServer<Block>>,
+	pub downloader: Arc<dyn BlockDownloader>,
+	pub request_response_config: ProtocolConfig,
+}
+
+

--- a/client/network/sync/src/engine.rs
+++ b/client/network/sync/src/engine.rs
@@ -20,6 +20,7 @@
 //! to tip and keep the blockchain up to date with network updates.
 
 use crate::{
+	block_relay_protocol::BlockDownloader,
 	service::{self, chain_sync::ToServiceCommand},
 	ChainSync, ClientError, SyncingService,
 };
@@ -257,7 +258,7 @@ where
 		warp_sync_params: Option<WarpSyncParams<B>>,
 		network_service: service::network::NetworkServiceHandle,
 		import_queue: Box<dyn ImportQueueService<B>>,
-		block_request_protocol_name: ProtocolName,
+		block_downloader: Arc<dyn BlockDownloader>,
 		state_request_protocol_name: ProtocolName,
 		warp_sync_protocol_name: Option<ProtocolName>,
 		rx: sc_utils::mpsc::TracingUnboundedReceiver<sc_network::SyncEvent<B>>,
@@ -328,7 +329,7 @@ where
 			metrics_registry,
 			network_service.clone(),
 			import_queue,
-			block_request_protocol_name,
+			block_downloader,
 			state_request_protocol_name,
 			warp_sync_protocol_name,
 			force_synced,

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -94,9 +94,13 @@ use std::{
 };
 
 pub use service::chain_sync::SyncingService;
+pub use schema::v1::{
+	BlockData as BlockDataSchema, BlockRequest as BlockRequestSchema,
+	BlockResponse as BlockResponseScheme, Direction as DirectionSchema,
+};
 
 mod extra_requests;
-pub mod schema;
+mod schema;
 
 pub mod block_relay_protocol;
 pub mod block_request_handler;

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -96,7 +96,7 @@ use std::{
 pub use service::chain_sync::SyncingService;
 
 mod extra_requests;
-mod schema;
+pub mod schema;
 
 pub mod block_relay_protocol;
 pub mod block_request_handler;

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -30,6 +30,7 @@
 
 use crate::{
 	blocks::BlockCollection,
+	block_relay_protocol::BlockDownloader,
 	schema::v1::{StateRequest, StateResponse},
 	state::StateSync,
 	warp::{WarpProofImportResult, WarpSync},
@@ -97,6 +98,7 @@ pub use service::chain_sync::SyncingService;
 mod extra_requests;
 mod schema;
 
+pub mod block_relay_protocol;
 pub mod block_request_handler;
 pub mod blocks;
 pub mod engine;
@@ -335,8 +337,8 @@ pub struct ChainSync<B: BlockT, Client> {
 	network_service: service::network::NetworkServiceHandle,
 	/// Protocol name used for block announcements
 	block_announce_protocol_name: ProtocolName,
-	/// Protocol name used to send out block requests
-	block_request_protocol_name: ProtocolName,
+	/// Block downloader stub
+	block_downloader: Arc<dyn BlockDownloader>,
 	/// Protocol name used to send out state requests
 	state_request_protocol_name: ProtocolName,
 	/// Protocol name used to send out warp sync requests
@@ -1364,23 +1366,20 @@ where
 	}
 
 	fn send_block_request(&mut self, who: PeerId, request: BlockRequest<B>) {
-		let (tx, rx) = oneshot::channel();
 		let opaque_req = self.create_opaque_block_request(&request);
-
-		if self.peers.contains_key(&who) {
-			self.pending_responses
-				.push(Box::pin(async move { (who, PeerRequest::Block(request), rx.await) }));
-		}
-
 		match self.encode_block_request(&opaque_req) {
 			Ok(data) => {
-				self.network_service.start_request(
-					who,
-					self.block_request_protocol_name.clone(),
-					data,
-					tx,
-					IfDisconnected::ImmediateError,
-				);
+				// Send the request even if the peer is not known. This would cause
+				// a failure to be returned. This simulates the existing behavior.
+				let network = self.network_service.clone();
+				let downloader = self.block_downloader.clone();
+				self.pending_responses.push(Box::pin(async move {
+					(
+						who,
+						PeerRequest::Block(request),
+						downloader.download_block(who, data, network).await
+					)
+				}));
 			},
 			Err(err) => {
 				log::warn!(
@@ -1418,7 +1417,7 @@ where
 		metrics_registry: Option<&Registry>,
 		network_service: service::network::NetworkServiceHandle,
 		import_queue: Box<dyn ImportQueueService<B>>,
-		block_request_protocol_name: ProtocolName,
+		block_downloader: Arc<dyn BlockDownloader>,
 		state_request_protocol_name: ProtocolName,
 		warp_sync_protocol_name: Option<ProtocolName>,
 		force_synced: bool,
@@ -1458,7 +1457,7 @@ where
 			import_existing: false,
 			gap_sync: None,
 			network_service,
-			block_request_protocol_name,
+			block_downloader,
 			state_request_protocol_name,
 			warp_sync_params,
 			warp_sync_protocol_name,

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -96,7 +96,7 @@ use std::{
 pub use service::chain_sync::SyncingService;
 pub use schema::v1::{
 	BlockData as BlockDataSchema, BlockRequest as BlockRequestSchema,
-	BlockResponse as BlockResponseScheme, Direction as DirectionSchema,
+	BlockResponse as BlockResponseSchema, Direction as DirectionSchema,
 };
 
 mod extra_requests;

--- a/client/network/sync/src/lib.rs
+++ b/client/network/sync/src/lib.rs
@@ -97,6 +97,7 @@ pub use service::chain_sync::SyncingService;
 pub use schema::v1::{
 	BlockData as BlockDataSchema, BlockRequest as BlockRequestSchema,
 	BlockResponse as BlockResponseSchema, Direction as DirectionSchema,
+	block_request::FromBlock as FromBlockSchema,
 };
 
 mod extra_requests;

--- a/client/network/sync/src/schema.rs
+++ b/client/network/sync/src/schema.rs
@@ -18,6 +18,6 @@
 
 //! Include sources generated from protobuf definitions.
 
-pub(crate) mod v1 {
+pub mod v1 {
 	include!(concat!(env!("OUT_DIR"), "/api.v1.rs"));
 }

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -843,12 +843,10 @@ where
 
 		let fork_id = Some(String::from("test-fork-id"));
 
-		let block_request_protocol_config = {
-			let (handler, protocol_config) =
-				BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
-			self.spawn_task(handler.run().boxed());
-			protocol_config
-		};
+		let mut block_relay_params = BlockRequestHandler::new(&protocol_id, None, client.clone(), 50);
+		self.spawn_task(Box::pin(async move {
+			block_relay_params.server.run().await;
+		}));
 
 		let state_request_protocol_config = {
 			let (handler, protocol_config) =
@@ -909,7 +907,7 @@ where
 				Some(warp_sync_params),
 				chain_sync_network_handle,
 				import_queue.service(),
-				block_request_protocol_config.name.clone(),
+				block_relay_params.downloader,
 				state_request_protocol_config.name.clone(),
 				Some(warp_protocol_config.name.clone()),
 				rx,
@@ -934,7 +932,7 @@ where
 			block_announce_config,
 			tx,
 			request_response_protocol_configs: [
-				block_request_protocol_config,
+				block_relay_params.request_response_config,
 				state_request_protocol_config,
 				light_client_request_protocol_config,
 				warp_protocol_config,

--- a/client/network/transactions/src/lib.rs
+++ b/client/network/transactions/src/lib.rs
@@ -281,7 +281,7 @@ struct Peer<H: ExHashT> {
 impl<B, H, N, S> TransactionsHandler<B, H, N, S>
 where
 	B: BlockT + 'static,
-	H: ExHashT,
+	H: ExHashT + std::fmt::Display,
 	N: NetworkPeers + NetworkEventStream + NetworkNotification,
 	S: SyncEventStream + sp_consensus::SyncOracle,
 {
@@ -418,6 +418,7 @@ where
 
 				self.network.report_peer(who, rep::ANY_TRANSACTION);
 
+				warn!(target: "sync", "Received {:?} from {:?}", hash, who);
 				match self.pending_transactions_peers.entry(hash.clone()) {
 					Entry::Vacant(entry) => {
 						self.pending_transactions.push(PendingTransaction {

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -43,6 +43,7 @@ use sc_network_bitswap::BitswapRequestHandler;
 use sc_network_common::{role::Roles, sync::warp::WarpSyncParams};
 use sc_network_light::light_client_requests::handler::LightClientRequestHandler;
 use sc_network_sync::{
+	block_relay_protocol::BlockRelayParams,
 	block_request_handler::BlockRequestHandler, engine::SyncingEngine,
 	service::network::NetworkServiceProvider, state_request_handler::StateRequestHandler,
 	warp_request_handler::RequestHandler as WarpSyncRequestHandler, SyncingService,
@@ -708,6 +709,9 @@ pub struct BuildNetworkParams<'a, TBl: BlockT, TExPool, TImpQu, TCl> {
 		Option<Box<dyn FnOnce(Arc<TCl>) -> Box<dyn BlockAnnounceValidator<TBl> + Send> + Send>>,
 	/// Optional warp sync params.
 	pub warp_sync_params: Option<WarpSyncParams<TBl>>,
+	/// User specified block relay params. If not specified, the default
+	/// block request handler will be used.
+	pub block_relay: Option<BlockRelayParams<TBl>>,
 }
 /// Build the network service, the network status sinks and an RPC sender.
 pub fn build_network<TBl, TExPool, TImpQu, TCl>(
@@ -744,6 +748,7 @@ where
 		import_queue,
 		block_announce_validator_builder,
 		warp_sync_params,
+		block_relay,
 	} = params;
 
 	let mut request_response_protocol_configs = Vec::new();
@@ -768,18 +773,23 @@ where
 		Box::new(DefaultBlockAnnounceValidator)
 	};
 
-	let block_request_protocol_config = {
-		// Allow both outgoing and incoming requests.
-		let (handler, protocol_config) = BlockRequestHandler::new(
-			&protocol_id,
-			config.chain_spec.fork_id(),
-			client.clone(),
-			config.network.default_peers_set.in_peers as usize +
-				config.network.default_peers_set.out_peers as usize,
-		);
-		spawn_handle.spawn("block-request-handler", Some("networking"), handler.run());
-		protocol_config
+	let (mut block_server, block_downloader, block_request_protocol_config) = match block_relay {
+		Some(params) => (params.server, params.downloader, params.request_response_config),
+		None => {
+			// Custom protocol was not specified, use the default block handler.
+			let params = BlockRequestHandler::new(
+				&protocol_id,
+				config.chain_spec.fork_id(),
+				client.clone(),
+				config.network.default_peers_set.in_peers as usize +
+					config.network.default_peers_set.out_peers as usize,
+			);
+			(params.server, params.downloader, params.request_response_config)
+		}
 	};
+	spawn_handle.spawn("block-request-handler", Some("networking"), async move {
+		block_server.run().await;
+	});
 
 	let state_request_protocol_config = {
 		// Allow both outgoing and incoming requests.
@@ -836,7 +846,7 @@ where
 		warp_sync_params,
 		chain_sync_network_handle,
 		import_queue.service(),
-		block_request_protocol_config.name.clone(),
+		block_downloader,
 		state_request_protocol_config.name.clone(),
 		warp_sync_protocol_config.as_ref().map(|config| config.name.clone()),
 		rx,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -508,7 +508,8 @@ where
 					Ok(sc_transaction_pool_api::error::Error::AlreadyImported(_)) =>
 						TransactionImport::KnownGood,
 					Ok(e) => {
-						debug!("Error adding transaction to the pool: {:?}", e);
+						warn!("xxx: import(): Error adding transaction to the pool = {:?}, best = {:?}",
+							best_block_id, e);
 						TransactionImport::Bad
 					},
 					Err(e) => {

--- a/client/transaction-pool/api/Cargo.toml
+++ b/client/transaction-pool/api/Cargo.toml
@@ -10,6 +10,7 @@ description = "Transaction pool client facing API."
 
 [dependencies]
 async-trait = "0.1.57"
+codec = { package = "parity-scale-codec", version = "3.2.2" }
 futures = "0.3.21"
 log = "0.4.17"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/client/transaction-pool/api/src/lib.rs
+++ b/client/transaction-pool/api/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod error;
 
 use async_trait::async_trait;
+use codec::Codec;
 use futures::{Future, Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sp_runtime::{
@@ -186,7 +187,7 @@ pub trait TransactionPool: Send + Sync {
 	/// Block type.
 	type Block: BlockT;
 	/// Transaction hash type.
-	type Hash: Hash + Eq + Member + Serialize + DeserializeOwned;
+	type Hash: Hash + Eq + Member + Serialize + DeserializeOwned + Codec;
 	/// In-pool transaction type.
 	type InPoolTransaction: InPoolTransaction<
 		Transaction = TransactionFor<Self>,


### PR DESCRIPTION
Main changes:
1. `ChainSync` currently calls into the block request handler directly. Instead, move the block request handler behind a trait. This allows new protocols to be plugged into ChainSync.
2. `BuildNetworkParams` is changed so that custom relay protocol implementations can be (optionally) passed in during network creation time. If custom protocol is not specified, it defaults to the existing block handler
3. `BlockServer` and `BlockDownloader` traits are introduced for the protocol implementation. The existing block handler has been changed to implement these traits
4. Export the block request related protobuf schemas