### PR TITLE
Patch upstream changes for building custom network

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -713,6 +713,7 @@ pub struct BuildNetworkParams<'a, TBl: BlockT, TExPool, TImpQu, TCl> {
 	/// block request handler will be used.
 	pub block_relay: Option<BlockRelayParams<TBl>>,
 }
+
 /// Build the network service, the network status sinks and an RPC sender.
 pub fn build_network<TBl, TExPool, TImpQu, TCl>(
 	params: BuildNetworkParams<TBl, TExPool, TImpQu, TCl>,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -211,7 +211,7 @@ async fn build_network_future<
 }
 
 /// Builds a future that processes system RPC requests.
-async fn build_system_rpc_future<
+pub async fn build_system_rpc_future<
 	B: BlockT,
 	C: BlockchainEvents<B>
 		+ HeaderBackend<B>
@@ -439,6 +439,13 @@ where
 pub struct TransactionPoolAdapter<C, P> {
 	pool: Arc<P>,
 	client: Arc<C>,
+}
+
+impl<C, P> TransactionPoolAdapter<C, P> {
+	/// Constructs a new instance of [`TransactionPoolAdapter`].
+	pub fn new(pool: Arc<P>, client: Arc<C>) -> Self {
+		Self { pool, client }
+	}
 }
 
 /// Get transactions for propagation.


### PR DESCRIPTION
This PR pick https://github.com/paritytech/substrate/pull/14238, which will be used to build our custom domain subnet (namely disable the block sync for the domain subnet) 